### PR TITLE
adding grep to go install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV DOTNET_ROOT="/root/.dotnet"
 ENV PATH="/root/.dotnet:${PATH}"
 
 FROM base AS go
-RUN curl -sfSL "https://go.dev/dl/$(curl -sfSL 'https://go.dev/VERSION?m=text').linux-arm64.tar.gz" -o go.tar.gz && \
+RUN curl -sfSL "https://go.dev/dl/$(curl -sfSL 'https://go.dev/VERSION?m=text'| grep 'go').linux-arm64.tar.gz" -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
When the build command executes, it runs 
```
curl -sfSL 'https://go.dev/VERSION?m=text'
```
The result of that command includes the time, and does not respect the -s flag. 
```
lisakoivu >curl -sfSL 'https://go.dev/VERSION?m=text'
go1.22.1
time 2024-02-29T18:18:48Z
```
Adding the grep ensures the time is not returned. If more than one value returns from this command, the build fails. Here's the updated code:

```
curl -sfSL 'https://go.dev/VERSION?m=text'| grep 'go'
```
and an example run
```
lisakoivu >curl -sfSL 'https://go.dev/VERSION?m=text'| grep go
go1.22.1
```